### PR TITLE
Use _DARWIN_C_SOURCE on macOS, not _GNU_SOURCE

### DIFF
--- a/src/compat.c
+++ b/src/compat.c
@@ -1,5 +1,9 @@
 #define _POSIX_C_SOURCE 200809L
+#ifdef __APPLE__
+#define _DARWIN_C_SOURCE
+#else
 #define _GNU_SOURCE
+#endif
 #define _CRT_RAND_S
 #define _CRT_NONSTDC_NO_DEPRECATE
 

--- a/tools/config/configure.R
+++ b/tools/config/configure.R
@@ -31,7 +31,11 @@ if (.Platform$OS.type != "windows") {
   tmpl <- "
 #pragma GCC diagnostic error \"-Wimplicit-function-declaration\"
 #define _POSIX_C_SOURCE 200809L
+#ifdef __APPLE__
+#define _DARWIN_C_SOURCE
+#else
 #define _GNU_SOURCE
+#endif
 #include <stdlib.h>
 int f() {
   return arc4random();
@@ -45,7 +49,11 @@ int f() {
   tmpl <- "
 #pragma GCC diagnostic error \"-Wimplicit-function-declaration\"
 #define _POSIX_C_SOURCE 200809L
+#ifdef __APPLE__
+#define _DARWIN_C_SOURCE
+#else
 #define _GNU_SOURCE
+#endif
 #include <unistd.h>
 int f() {
   unsigned int u;


### PR DESCRIPTION
Setting `_POSIX_C_SOURCE` on macOS can have an effect of disabling otherwise available functions, in particular `arc4random`. Use `_DARWIN_C_SOURCE`, which solves the issue.